### PR TITLE
Update misc.py

### DIFF
--- a/imagebind_LLM/util/misc.py
+++ b/imagebind_LLM/util/misc.py
@@ -21,7 +21,7 @@ from tqdm import tqdm
 import torch
 import torch.utils.data
 import torch.distributed as dist
-from torch._six import inf
+from torch import inf
 
 
 class SmoothedValue(object):


### PR DESCRIPTION
fixed No module named 'torch._six' 
updated the depricated module with 
`from torch import six`
updated from https://github.com/microsoft/DeepSpeed/issues/2845