### PR TITLE
Update demo.py to fix the override of llama_type

### DIFF
--- a/llama_adapter_v2_multimodal7b/demo.py
+++ b/llama_adapter_v2_multimodal7b/demo.py
@@ -8,7 +8,7 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 llama_dir = "/path/to/LLaMA/"
 
 # choose from BIAS-7B, LORA-BIAS-7B, CAPTION-7B.pth
-model, preprocess = llama.load("BIAS-7B", llama_dir, device)
+model, preprocess = llama.load("BIAS-7B", llama_dir, device=device)
 model.eval()
 
 prompt = llama.format_prompt('Please introduce this painting.')


### PR DESCRIPTION
As the definition of the function load, need to specify the parameter name of device.

`def load(name, llama_dir, llama_type="7B", device="xxx", download_root='ckpts', max_seq_len=512,
        phase="finetune")
`